### PR TITLE
ensure data and type are set correctly

### DIFF
--- a/android/src/main/java/com/poberwong/launcher/IntentLauncherModule.java
+++ b/android/src/main/java/com/poberwong/launcher/IntentLauncherModule.java
@@ -60,11 +60,17 @@ public class IntentLauncherModule extends ReactContextBaseJavaModule implements 
         if (params.hasKey(ATTR_ACTION)) {
             intent.setAction(params.getString(ATTR_ACTION));
         }
-        if (params.hasKey(ATTR_DATA)) {
-            intent.setData(Uri.parse(params.getString(ATTR_DATA)));
-        }
-        if (params.hasKey(ATTR_TYPE)) {
-            intent.setType(params.getString(ATTR_TYPE));
+        // setting data resets type; and setting type resets data; if you have both, you need to set them at the same time
+        // https://developer.android.com/guide/components/intents-filters.html#Types (see 'Data' section)
+        if (params.hasKey(ATTR_DATA) && params.hasKey(ATTR_TYPE)) {
+            intent.setDataAndType(Uri.parse(params.getString(ATTR_DATA)), params.getString(ATTR_TYPE));
+        } else {
+            if (params.hasKey(ATTR_DATA)) {
+                intent.setData(Uri.parse(params.getString(ATTR_DATA)));
+            }
+            if (params.hasKey(ATTR_TYPE)) {
+                intent.setType(params.getString(ATTR_TYPE));
+            }
         }
         if (params.hasKey(TAG_EXTRA)) {
             intent.putExtras(Arguments.toBundle(params.getMap(TAG_EXTRA)));


### PR DESCRIPTION
If you set `type`, `data` will be reset and vice versa.  This patch uses `setDataAndType()` when both are necessary.

From https://developer.android.com/guide/components/intents-filters.html#Types ('Data' section)

> Caution:
> If you want to set both the URI and MIME type, don't call setData() and setType() because they each nullify the value of the other. Always use setDataAndType() to set both URI and MIME type.